### PR TITLE
Added fields Width, Height, and Depth for displaying cell dimensions

### DIFF
--- a/force-app/main/default/objects/Cell__c/fields/Depth__c.field-meta.xml
+++ b/force-app/main/default/objects/Cell__c/fields/Depth__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Depth__c</fullName>
+    <externalId>false</externalId>
+    <formula>48.5</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Depth (cm)</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Cell__c/fields/Height__c.field-meta.xml
+++ b/force-app/main/default/objects/Cell__c/fields/Height__c.field-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Height__c</fullName>
+    <externalId>false</externalId>
+    <formula>CASE(TEXT(Size__c),
+&quot;Small&quot;, 10,
+&quot;Medium&quot;, 10,
+&quot;Big&quot;, 14.6,
+&quot;Large&quot;, 15.4,
+&quot;Extra Large&quot;, 23.7,
+&quot;Jumbo&quot;, 23.7,
+&quot;Mega&quot;, 47.4,
+0)</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Height (cm)</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Cell__c/fields/Width__c.field-meta.xml
+++ b/force-app/main/default/objects/Cell__c/fields/Width__c.field-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Width__c</fullName>
+    <externalId>false</externalId>
+    <formula>CASE(TEXT(Size__c),
+&quot;Small&quot;, 16.4,
+&quot;Medium&quot;, 33.2,
+&quot;Big&quot;, 47.4,
+&quot;Large&quot;, 47.4,
+&quot;Extra Large&quot;, 47.4,
+&quot;Jumbo&quot;, 47.4,
+&quot;Mega&quot;, 47.4,
+0)</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>Width (cm)</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Added fields Width, Height, and Depth of type Formula field. When a size is selected in the Size field, the appropriate dimensions are automatically set for the Width, Height, and Depth fields. Before merging this pull request, it is advisable to merge pull request https://github.com/msenyk/sf-practicum-2024/pull/12, as there are fields here that depend on new Size__c values.